### PR TITLE
Added support for serde.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,9 +1,16 @@
 root = true
 
-[*]
+[*.{js,json,ts}]
 indent_style = space
 indent_size = 2
 charset = utf-8
 trim_trailing_whitespace = false
 insert_final_newline = false
 quote_type = single
+
+[*.rs]
+indent_style = space
+indent_size = 4
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/rust-lib/Cargo.lock
+++ b/rust-lib/Cargo.lock
@@ -238,9 +238,12 @@ version = "1.0.3"
 dependencies = [
  "console_error_panic_hook",
  "criterion",
+ "email-address-parser",
  "pest",
  "pest_derive",
  "quick-xml",
+ "serde",
+ "serde_json",
  "wasm-bindgen",
  "wasm-bindgen-test",
 ]
@@ -565,6 +568,9 @@ name = "serde"
 version = "1.0.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e54c9a88f2da7238af84b5101443f0c0d0a3bbdc455e34a5c9497b1903ed55d5"
+dependencies = [
+ "serde_derive",
+]
 
 [[package]]
 name = "serde_cbor"

--- a/rust-lib/Cargo.toml
+++ b/rust-lib/Cargo.toml
@@ -22,13 +22,16 @@ pest = "^2.1.3"
 pest_derive = "^2.1.0"
 wasm-bindgen = "^0.2.67"
 console_error_panic_hook = "^0.1.6"
+serde = { version = "1.0.115", features = ["derive"], optional = true }
 
 [build-dependencies]
 quick-xml = "^0.18.1"
 
 [dev-dependencies]
+email-address-parser = { path = ".", features = ["serde"] }
 wasm-bindgen-test = "^0.3.17"
 criterion = "^0.3.3"
+serde_json = "1.0.57"
 
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = ["-Oz", "--enable-mutable-globals"]

--- a/rust-lib/tests/email_address_tests.rs
+++ b/rust-lib/tests/email_address_tests.rs
@@ -1,3 +1,5 @@
+use serde_json::{Error, json};
+
 use email_address_parser::EmailAddress;
 
 #[test]
@@ -15,4 +17,39 @@ fn test_clone() {
     // ensure it exists after the source is dropped
     assert_eq!("foo", actual.get_local_part());
     assert_eq!("bar.com", actual.get_domain());
+}
+
+#[test]
+fn test_serialize() {
+    let actual = serde_json::to_value(EmailAddress::new("foo", "bar.baz", None).unwrap()).unwrap();
+
+    assert_eq!(json!({"local_part":"foo","domain":"bar.baz"}), actual);
+}
+
+#[test]
+fn test_deserialize_valid() {
+    let actual: EmailAddress = serde_json::from_value(json!({"local_part":"foo","domain":"bar.baz"})).unwrap();
+
+    assert_eq!(EmailAddress::new("foo", "bar.baz", None).unwrap(), actual);
+}
+
+#[test]
+fn test_deserialize_invalid() {
+    let error_1: Result<EmailAddress, Error> = serde_json::from_value(json!({"local_part":"foo","domain":""}));
+    let error_2: Result<EmailAddress, Error> = serde_json::from_value(json!({"local_part":"","domain":"bar.baz"}));
+    let error_3: Result<EmailAddress, Error> = serde_json::from_value(json!({"localpart":"foo","domain":"bar.baz"}));
+    let error_4: Result<EmailAddress, Error> = serde_json::from_value(json!({"local_part":"foo","domaine":"bar.baz"}));
+    let error_5: Result<EmailAddress, Error> = serde_json::from_value(json!({"local_part":"foo","domain":"bar.baz","ques":"que.se"}));
+    let error_6: Result<EmailAddress, Error> = serde_json::from_value(json!({"local_part":"foo"}));
+    let error_7: Result<EmailAddress, Error> = serde_json::from_value(json!({"domain":"bar.baz"}));
+    let error_8: Result<EmailAddress, Error> = serde_json::from_value(json!({}));
+
+    assert!(error_1.is_err());
+    assert!(error_2.is_err());
+    assert!(error_3.is_err());
+    assert!(error_4.is_err());
+    assert!(error_5.is_err());
+    assert!(error_6.is_err());
+    assert!(error_7.is_err());
+    assert!(error_8.is_err());
 }


### PR DESCRIPTION
We would like to be able to send validated email addresses between servers. This pull request adds `serde` support to `EmailAddress` so it can be communicated across the wire in a modeled way. The (de)serialization assumes strict mode. The `"serde"` feature is optional and off by default.

Versions:

```
serde = "1.0.115"
serde_json = "1.0.57"
```

were used because they were preexisting in the lock file and the latest patch versions caused compilation errors.

I restricted the existing editor config to non-rust files because intellij was using 2-space tabs in rust files when 4 is desired.