### PR TITLE
Make wasm-bindgen dependency optional.

### DIFF
--- a/rust-lib/Cargo.toml
+++ b/rust-lib/Cargo.toml
@@ -20,14 +20,18 @@ crate-type = ["lib", "cdylib"]
 [dependencies]
 pest = "^2.1.3"
 pest_derive = "^2.1.0"
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = "^0.2.67"
 console_error_panic_hook = "^0.1.6"
 
 [build-dependencies]
 quick-xml = "^0.18.1"
 
-[dev-dependencies]
+[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 wasm-bindgen-test = "^0.3.17"
+
+[dev-dependencies]
 criterion = "^0.3.3"
 
 [package.metadata.wasm-pack.profile.release]

--- a/rust-lib/build.rs
+++ b/rust-lib/build.rs
@@ -94,11 +94,13 @@ macro_rules! generate_positive_parsing_test {
     #[cfg(test)]
     mod parses_valid_email_address {
       use email_address_parser::*;
+      #[cfg(target_arch = \"wasm32\")]
       use wasm_bindgen_test::*;
+      #[cfg(target_arch = \"wasm32\")]
       wasm_bindgen_test_configure!(run_in_browser);
       $(
         #[test]
-        #[wasm_bindgen_test]
+        #[cfg_attr(target_arch = \"wasm32\", wasm_bindgen_test)]
         fn $case() {
           let address_str = concat!($local_part, \"@\", $domain);
           let address = EmailAddress::parse(&address_str, None);
@@ -135,11 +137,13 @@ macro_rules! generate_negative_parsing_test {
     #[cfg(test)]
     mod does_not_parse_invalid_email_address {
       use email_address_parser::*;
+      #[cfg(target_arch = \"wasm32\")]
       use wasm_bindgen_test::*;
+      #[cfg(target_arch = \"wasm32\")]
       wasm_bindgen_test_configure!(run_in_browser);
       $(
         #[test]
-        #[wasm_bindgen_test]
+        #[cfg_attr(target_arch = \"wasm32\", wasm_bindgen_test)]
         fn $case() {
           let address_str = concat!($local_part, \"@\", $domain);
           assert_eq!(EmailAddress::parse(&address_str, None).is_none(), true, \"expected {} not to be parsed\", address_str);
@@ -170,11 +174,13 @@ macro_rules! generate_is_email_test {
     #[cfg(test)]
     mod is_email_parsing_tests {
       use email_address_parser::*;
+      #[cfg(target_arch = \"wasm32\")]
       use wasm_bindgen_test::*;
+      #[cfg(target_arch = \"wasm32\")]
       wasm_bindgen_test_configure!(run_in_browser);
       $(
         #[test]
-        #[wasm_bindgen_test]
+        #[cfg_attr(target_arch = \"wasm32\", wasm_bindgen_test)]
         fn $case() {
           let email = EmailAddress::parse(&$email, Some(ParsingOptions::new(true)));
           assert_eq!(email.is_some(), $is_email, \"expected {} to be valid: {}\", $email, $is_email);
@@ -276,11 +282,13 @@ macro_rules! generate_positive_instantiation_test {
     #[cfg(test)]
     mod instantiates_valid_email_address {
       use email_address_parser::*;
+      #[cfg(target_arch = \"wasm32\")]
       use wasm_bindgen_test::*;
+      #[cfg(target_arch = \"wasm32\")]
       wasm_bindgen_test_configure!(run_in_browser);
       $(
         #[test]
-        #[wasm_bindgen_test]
+        #[cfg_attr(target_arch = \"wasm32\", wasm_bindgen_test)]
         fn $case() {
           let address = EmailAddress::new(&$local_part, &$domain, Some(ParsingOptions::new(true))).unwrap();
           assert_eq!(address.get_local_part(), $local_part);
@@ -314,11 +322,13 @@ macro_rules! generate_negative_instantiation_test {
     #[cfg(test)]
     mod panics_instantiating_invalid_email_address {
       use email_address_parser::*;
+      #[cfg(target_arch = \"wasm32\")]
       use wasm_bindgen_test::*;
+      #[cfg(target_arch = \"wasm32\")]
       wasm_bindgen_test_configure!(run_in_browser);
       $(
         #[test]
-        #[wasm_bindgen_test]
+        #[cfg_attr(target_arch = \"wasm32\", wasm_bindgen_test)]
         fn $case() {
           assert_eq!(EmailAddress::new(&$local_part, &$domain, Some(ParsingOptions::new(false))).is_err(), true);
           assert_eq!(EmailAddress::new(&$local_part, &$domain, Some(ParsingOptions::new(true))).is_err(), false);
@@ -372,11 +382,13 @@ macro_rules! generate_is_valid_test {
     #[cfg(test)]
     mod is_valid_email_address {
       use email_address_parser::*;
+      #[cfg(target_arch = \"wasm32\")]
       use wasm_bindgen_test::*;
+      #[cfg(target_arch = \"wasm32\")]
       wasm_bindgen_test_configure!(run_in_browser);
       $(
         #[test]
-        #[wasm_bindgen_test]
+        #[cfg_attr(target_arch = \"wasm32\", wasm_bindgen_test)]
         fn $case() {
           assert_eq!(EmailAddress::is_valid(&$address, None), $is_valid, \"expected {} to be valid: {}\", $address, $is_valid);
         }

--- a/rust-lib/src/email_address.rs
+++ b/rust-lib/src/email_address.rs
@@ -1,9 +1,11 @@
+#[cfg(target_arch = "wasm32")]
 extern crate console_error_panic_hook;
 extern crate pest;
 extern crate pest_derive;
 use pest::{iterators::Pairs, Parser};
 use std::fmt;
 use std::hash::Hash;
+#[cfg(target_arch = "wasm32")]
 use wasm_bindgen::prelude::*;
 
 /// Options for parsing.
@@ -11,15 +13,15 @@ use wasm_bindgen::prelude::*;
 /// The is only one available option so far `is_lax` which can be set to
 /// `true` or `false` to  enable/disable obsolete parts parsing.
 /// The default is `false`.
-#[wasm_bindgen]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
 #[derive(Debug,Clone)]
 pub struct ParsingOptions {
     pub is_lax: bool,
 }
 
-#[wasm_bindgen]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
 impl ParsingOptions {
-    #[wasm_bindgen(constructor)]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(constructor))]
     pub fn new(is_lax: bool) -> ParsingOptions {
         ParsingOptions { is_lax }
     }
@@ -49,14 +51,14 @@ struct RFC5322;
 /// assert_eq!(email.get_domain(), "bar.com");
 /// assert_eq!(format!("{}", email), "foo@bar.com");
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct EmailAddress {
     local_part: String,
     domain: String,
 }
 
-#[wasm_bindgen]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
 impl EmailAddress {
     #![warn(missing_docs)]
     #![warn(rustdoc::missing_doc_code_examples)]
@@ -81,8 +83,9 @@ impl EmailAddress {
     /// EmailAddress::_new("foo", "-bar.com", None);
     /// ```
     #[doc(hidden)]
-    #[wasm_bindgen(constructor)]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(constructor))]
     pub fn _new(local_part: &str, domain: &str, options: Option<ParsingOptions>) -> EmailAddress {
+        #[cfg(target_arch = "wasm32")]
         console_error_panic_hook::set_once();
         match EmailAddress::new(local_part, domain, options) {
             Ok(instance) => instance,
@@ -159,7 +162,7 @@ impl EmailAddress {
     /// assert!(!EmailAddress::is_valid("test", Some(ParsingOptions::new(true))));
     /// assert!(!EmailAddress::is_valid("test", Some(ParsingOptions::new(true))));
     /// ```
-    #[wasm_bindgen(js_name = "isValid")]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = "isValid"))]
     pub fn is_valid(input: &str, options: Option<ParsingOptions>) -> bool {
         EmailAddress::parse_core(input, options).is_some()
     }
@@ -181,7 +184,7 @@ impl EmailAddress {
     /// ```
     #[doc(hidden)]
     #[allow(non_snake_case)]
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(getter))]
     pub fn localPart(&self) -> String {
         self.local_part.clone()
     }
@@ -202,7 +205,7 @@ impl EmailAddress {
     /// assert_eq!(email.domain(), "bar.com");
     /// ```
     #[doc(hidden)]
-    #[wasm_bindgen(getter)]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(getter))]
     pub fn domain(&self) -> String {
         self.domain.clone()
     }
@@ -211,7 +214,7 @@ impl EmailAddress {
     /// This exists purely for WASM interoperability.
     #[doc(hidden)]
     #[allow(non_snake_case)]
-    #[wasm_bindgen(skip_typescript)]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(skip_typescript))]
     pub fn toString(&self) -> String {
         format!("{}@{}", self.local_part, self.domain)
     }


### PR DESCRIPTION
`wasm-bindgen` (and `console_error_panic_hook`) are only needed on wasm32-* targets, on other platform it can be safely ignored to save compilation time.

On my machine in dev profile I have 40 dependencies compiled in ~18s dev vs 25 dependencies compiled in ~15.5s so basically ~15% less time on compilation.
Of course the drawback is that the code get sprayed by `#[cfg(target_arch = "wasm32"]` 😄 

BTW merry Christmas ! 🎅 🎁 🌲 