### PR TITLE
add FromStr method for EmailAddress

### DIFF
--- a/rust-lib/Cargo.toml
+++ b/rust-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "email-address-parser"
-version = "2.0.0-rc3"
+version = "2.1.0-rc3"
 authors = ["Sayan751"]
 edition = "2018"
 description = "An RFC 5322, and RFC 6532 compliant email address parser."

--- a/rust-lib/Cargo.toml
+++ b/rust-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "email-address-parser"
-version = "2.1.0-rc3"
+version = "2.0.0-rc3"
 authors = ["Sayan751"]
 edition = "2018"
 description = "An RFC 5322, and RFC 6532 compliant email address parser."

--- a/rust-lib/src/email_address.rs
+++ b/rust-lib/src/email_address.rs
@@ -5,6 +5,7 @@ extern crate pest_derive;
 use pest::{iterators::Pairs, Parser};
 use std::fmt;
 use std::hash::Hash;
+use std::str::FromStr;
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen::prelude::*;
 
@@ -30,6 +31,18 @@ impl ParsingOptions {
 impl Default for ParsingOptions {
     fn default() -> Self {
         ParsingOptions::new(false)
+    }
+}
+
+impl FromStr for EmailAddress {
+    type Err = fmt::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if let Some(email) = EmailAddress::parse(s, None) {
+            Ok(email)
+        } else {
+            Err(fmt::Error)
+        }
     }
 }
 

--- a/rust-lib/src/email_address.rs
+++ b/rust-lib/src/email_address.rs
@@ -34,11 +34,27 @@ impl Default for ParsingOptions {
     }
 }
 
+/// Allows conversion from string slices (&str) to EmailAddress using the FromStr trait.
+/// This wraps around `EmailAddress::parse` using the default `ParsingOptions`.
+///
+/// # Examples
+/// ```
+/// use email_address_parser::EmailAddress;
+/// use std::str::FromStr;
+///
+/// const input_address : &str = "string@slice.com";
+///
+/// let myaddr : EmailAddress = input_address.parse().expect("could not parse str into EmailAddress");
+/// let myotheraddr = EmailAddress::from_str(input_address).expect("could create EmailAddress from str");
+///
+/// assert_eq!(myaddr, myotheraddr);
+/// ```
 impl FromStr for EmailAddress {
     type Err = fmt::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if let Some(email) = EmailAddress::parse(s, None) {
+        let opts = ParsingOptions::default();
+        if let Some(email) = EmailAddress::parse(s, Some(opts)) {
             Ok(email)
         } else {
             Err(fmt::Error)


### PR DESCRIPTION
This allows `EmailAddress` to be used with `clap`, the commandline argument parser.

FromStr is just wrapping around the existing `EmailAddress::parse` method, using the default options (`is_lax = false` at time of writing).


This allows the following:
```rust
use clap::Parser;
use email_address_parser::EmailAddress;

#[derive(Parser, Debug)]
#[command(author, version, about, long_about = None)]
struct Args {
    #[arg(short, long, help = "your email address")]
    email: EmailAddress,
}

fn main() {
    let args = Args::parse();
    println!("Hello {}!", args.email)
}
```