### PR TITLE
Update `quick-xml` version for RUSTSEC-2026-0195

### DIFF
--- a/rust-lib/Cargo.lock
+++ b/rust-lib/Cargo.lock
@@ -458,9 +458,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.39.2"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]

--- a/rust-lib/Cargo.toml
+++ b/rust-lib/Cargo.toml
@@ -25,7 +25,7 @@ wasm-bindgen = "^0.2.111"
 console_error_panic_hook = "^0.1.7"
 
 [build-dependencies]
-quick-xml = "^0.39.2"
+quick-xml = "^0.41.0"
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 wasm-bindgen-test = "^0.3.61"


### PR DESCRIPTION

Closes: #16

For further details, read #16. 